### PR TITLE
Fix/path request

### DIFF
--- a/restful_fleet_client/launch/restful_fleet_client.launch
+++ b/restful_fleet_client/launch/restful_fleet_client.launch
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<launch>
+    <node name="restful_fleet_client" pkg="restful_fleet_client" type="app.py"  output="screen"/>
+</launch>

--- a/restful_fleet_client/scripts/app.py
+++ b/restful_fleet_client/scripts/app.py
@@ -1,7 +1,5 @@
 #! /usr/bin/env python3
 
-from distutils.command.config import config
-from pickle import TRUE
 import rospy
 from http import HTTPStatus
 from threading import Thread
@@ -41,9 +39,12 @@ socketio.init_app(app, cors_allowed_origins="*")
 @app.route(_client_config.path_request_route, methods=['POST'])
 def handle_path_request():
     path_request_json = request.json
-    rospy.loginfo(f"received path request: {path_request_json}")
-    _client_node.receive_path_request(path_request_json)
-    response = app.response_class(status=200)
+    rospy.loginfo(f"received path request of id: {path_request_json['task_id']}\
+        , of length {len(path_request_json['path'])}")
+    response = app.response_class(status=HTTPStatus.NOT_ACCEPTABLE.value)
+    if _client_node.receive_path_request(path_request_json):
+        rospy.loginfo("request is valid")
+        response = app.response_class(status=200)
     return response
 
 @app.route(_client_config.mode_request_route, methods=['POST'])

--- a/restful_fleet_client/scripts/restful_fleet_client/client_node.py
+++ b/restful_fleet_client/scripts/restful_fleet_client/client_node.py
@@ -211,9 +211,6 @@ class ClientNode():
         goal.target_pose.pose.orientation.z = quaternion[2]
         goal.target_pose.pose.orientation.w = quaternion[3]
 
-
-
-
         return goal
 
     def transform_to_location_json(self,transform):

--- a/restful_fleet_client/scripts/restful_fleet_client/client_node.py
+++ b/restful_fleet_client/scripts/restful_fleet_client/client_node.py
@@ -1,8 +1,5 @@
-from asyncio import FastChildWatcher
-from distutils.command.config import config
-from flask import Config
 from numpy import math
-
+from threading import Semaphore
 from requests import request
 from rx import catch
 import rospy
@@ -51,6 +48,8 @@ class ClientNode():
         self.paused = False
         self.request_error= False
         self.current_task_id = ""
+        self.task_validity_semaphore = Semaphore()
+
 
     def init(self):
         # in case we need to set up some stuff
@@ -66,11 +65,15 @@ class ClientNode():
 
     def is_valid_request(self, request_fleet_name, request_robot_name,\
         request_task_id) -> bool:
+        self.task_validity_semaphore.acquire()
         if (self.current_task_id == request_task_id\
             or self.config.robot_name != request_robot_name\
             or self.config.fleet_name != request_fleet_name):
             rospy.loginfo("not a valid request")
+            self.task_validity_semaphore.release()
             return False
+        self.current_task_id = request_task_id
+        self.task_validity_semaphore.release()
         return True
 
     def get_robot_transform(self) -> bool:
@@ -141,6 +144,8 @@ class ClientNode():
                 goal.goal_end_time = rospy.Time(int(goal_json["t"]["sec"]),\
                     int(goal_json["t"]["nanosec"]))
                 self.goal_path.append(goal)
+            # we wanna move the setting of the task id to be
+            # part of the critical section in the is valid request section
             self.current_task_id = path_req_json["task_id"]
 
             if self.paused:
@@ -190,6 +195,7 @@ class ClientNode():
                 quaternion)[2])
             location_json["level_name"] = self.config.level_name
             path.append(location_json)
+        rospy.loginfo(f"the goal path length is {len(self.goal_path)}")
         robot_state_json["path"] = path
         self.client.send_robot_state(robot_state_json)
 
@@ -232,6 +238,7 @@ class ClientNode():
     def loop(self):
         self.get_robot_transform()
         self.send_robot_state()
+        # execute path request if any
         if (len(self.goal_path) != 0):
             if (not self.goal_path[0].sent):
                 rospy.loginfo("Sending new goal!")
@@ -249,15 +256,16 @@ class ClientNode():
                     self.goal_path.pop(0)
                 else:
                     wait_time_remaining = self.goal_path[0].goal_end_time - rospy.Time.now()
-                    rospy.loginfo(f"we reached our goalearly! Waiting for \
+                    rospy.loginfo(f"we reached our goal early! Waiting for \
                         {wait_time_remaining.to_sec()} more seconds")
+                    self.goal_path.pop(0)
                 return
             elif current_goal_state == GoalStatus.ACTIVE:
                 return
             elif current_goal_state == GoalStatus.ABORTED:
-                self.goal_path[0].aborted_cout += 1
+                self.goal_path[0].aborted_count += 1
 
-                if (self.goal_path[0].aborted_cout < self.max_tries):
+                if (self.goal_path[0].aborted_count < self.max_tries):
                     rospy.loginfo(f"robot's naviation stack has been aborted the \
                         current goal {self.goal_path[0].aborted_count} times. Check if there is \
                             nothing in the way of the robot. Trying again .....")

--- a/restful_fleet_server/restful_fleet_server/server_node.py
+++ b/restful_fleet_server/restful_fleet_server/server_node.py
@@ -7,6 +7,7 @@ import json
 from rclpy.node import Node
 from rclpy.time import Time
 from rclpy.parameter import Parameter
+from threading import Semaphore
 
 # Qos
 from rclpy.qos import qos_profile_system_default
@@ -99,8 +100,12 @@ class ServerNode(Node):
             loc_json = self.convert_location_to_json(location)
             json_msg["path"].append(loc_json)
         json_msg["task_id"] = _msg.task_id
+        self.get_logger().info(
+            f"sending path request of length {len(json_msg['path'])}")
         self.server.send_path_request(json_msg)
-        self.get_logger().info("sending path request")
+        self.get_logger().info(
+            f"path request sent!")
+        return
 
     def handle_mode_request(self, _msg):
         return
@@ -170,7 +175,7 @@ class ServerNode(Node):
         for robot in self.robots:
             fleet_state.robots.append(self.robots[robot])
         self.fleet_state_pub.publish(fleet_state)
-        self.get_logger().info("Publishing fleet_states")
+        # self.get_logger().info("Publishing fleet_states")
 
     def publish_end_action(self, robot):
         mode_request = ModeRequest()

--- a/restful_fleet_server/restful_fleet_server/server_node_config.py
+++ b/restful_fleet_server/restful_fleet_server/server_node_config.py
@@ -3,7 +3,7 @@ class ServerNodeConfig():
     def __init__(self):
         self.node_name = "restful_fleet_server"
         self.fleet_name = "Unodopo"
-        self.timer_period = 10
+        self.timer_period = 0.5
         self.fleet_state_pub_rate = 10
         self.sub_rate = 10
 


### PR DESCRIPTION
# Fix Bug
This Fixes #4 
## Description
Previously, path requests were sometimes executed twice. This is as the `current_task_id` attribute of the `client node` was not updated before a repeated path request was received. Thus when the `task_id` of the repeated path request was deemed valid when it is not. 

## Fix
This pull request implements the usage of a semaphore to prevent race conditions when updating and checking the `current_task_id` attribute of the `client_node`